### PR TITLE
Add AbstractLanguageServer, type fixes, better parseState management

### DIFF
--- a/packages/sms-language-server/package.json
+++ b/packages/sms-language-server/package.json
@@ -1,8 +1,9 @@
 {
   "name": "sms-language-server",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
+  "types": "./dist/types/SmsLanguageServer.d.ts",
   "license": "Apache-2.0",
   "keywords": [
     "sms",
@@ -49,7 +50,7 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "millan": "^2.0.0",
-    "stardog-language-utils": "^1.0.0",
+    "stardog-language-utils": "^1.1.1",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sms-language-server/src/worker.ts
+++ b/packages/sms-language-server/src/worker.ts
@@ -1,7 +1,7 @@
 import { getWorkerConnection } from 'stardog-language-utils';
-import { SmsLanguageServer } from "./SmsLanguageServer";
+import { SmsLanguageServer } from './SmsLanguageServer';
 
 const connection = getWorkerConnection();
 const server = new SmsLanguageServer(connection);
 server.start();
-connection.onShutdown(self.close);
+connection.onExit(self.close);

--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -1,8 +1,9 @@
 {
   "name": "sparql-language-server",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
+  "types": "./dist/types/SparqlLanguageServer.ts",
   "license": "Apache-2.0",
   "keywords": [
     "sparql",
@@ -48,7 +49,7 @@
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniq": "^4.5.0",
     "millan": "^2.0.0",
-    "stardog-language-utils": "^1.0.0",
+    "stardog-language-utils": "^1.1.1",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sparql-language-server/src/worker.ts
+++ b/packages/sparql-language-server/src/worker.ts
@@ -1,7 +1,7 @@
 import { getWorkerConnection } from 'stardog-language-utils';
-import { SparqlLanguageServer } from "./SparqlLanguageServer";
+import { SparqlLanguageServer } from './SparqlLanguageServer';
 
 const connection = getWorkerConnection();
 const server = new SparqlLanguageServer(connection);
 server.start();
-connection.onShutdown(self.close);
+connection.onExit(self.close);

--- a/packages/stardog-language-utils/package.json
+++ b/packages/stardog-language-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog-language-utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types",
@@ -49,6 +49,7 @@
     "@types/node": "^10.12.15",
     "@types/yargs": "^12.0.1",
     "ci-info": "^2.0.0",
+    "copy-webpack-plugin": "^4.6.0",
     "fork-ts-checker-webpack-plugin": "^0.5.2",
     "npm-run-all": "^4.1.5",
     "rimraf": "^2.6.2",

--- a/packages/stardog-language-utils/package.json
+++ b/packages/stardog-language-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog-language-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types",

--- a/packages/stardog-language-utils/src/AbstractLanguageServer.ts
+++ b/packages/stardog-language-utils/src/AbstractLanguageServer.ts
@@ -45,8 +45,8 @@ export abstract class AbstractLanguageServer<
     // Setting this StarHandler is intended to overwrite the handler set
     // in the constructor, which always responded with a "Server not initialized"
     // error. Here, we're initialized, so we replace with an "Unhandled method"
-    this.connection.onRequest(this.handleUnhandledRequest);
-    this.connection.onHover(this.handleHover);
+    this.connection.onRequest(this.handleUnhandledRequest.bind(this));
+    this.connection.onHover(this.handleHover.bind(this));
     return this.onInitialization(params);
   }
 

--- a/packages/stardog-language-utils/src/AbstractLanguageServer.ts
+++ b/packages/stardog-language-utils/src/AbstractLanguageServer.ts
@@ -1,0 +1,205 @@
+import * as lsp from 'vscode-languageserver';
+import { Parser, IToken, IRecognitionException } from 'chevrotain';
+import { IStardogParser, isCstNode, traverse } from 'millan';
+import { ParseStateManager, getParseStateManager } from './parseState';
+
+export abstract class AbstractLanguageServer<
+  T extends Parser & IStardogParser
+> {
+  protected readonly documents: lsp.TextDocuments;
+  protected readonly parseStateManager: ParseStateManager;
+
+  constructor(
+    protected readonly connection: lsp.IConnection,
+    protected readonly parser: T
+  ) {
+    this.documents = new lsp.TextDocuments();
+    this.parseStateManager = getParseStateManager();
+    this.documents.listen(connection);
+    this.documents.onDidChangeContent(this.handleContentChange.bind(this));
+    this.documents.onDidClose(this.handleDocumentClose.bind(this));
+    this.connection.onRequest(this.handleUninitializedRequest.bind(this));
+    this.connection.onInitialize(this.handleInitialization.bind(this));
+  }
+
+  start() {
+    this.connection.listen();
+  }
+
+  handleUninitializedRequest: lsp.StarRequestHandler = () =>
+    new lsp.ResponseError(
+      lsp.ErrorCodes.ServerNotInitialized,
+      'Expecting "initialize" request from client.'
+    );
+
+  handleUnhandledRequest: lsp.StarRequestHandler = (method) =>
+    new lsp.ResponseError(
+      lsp.ErrorCodes.MethodNotFound,
+      `Request: "${method}" is not handled by the server.`
+    );
+
+  abstract onInitialization(params: lsp.InitializeParams);
+  private handleInitialization(
+    params: lsp.InitializeParams
+  ): lsp.InitializeResult {
+    // Setting this StarHandler is intended to overwrite the handler set
+    // in the constructor, which always responded with a "Server not initialized"
+    // error. Here, we're initialized, so we replace with an "Unhandled method"
+    this.connection.onRequest(this.handleUnhandledRequest);
+    this.connection.onHover(this.handleHover);
+    return this.onInitialization(params);
+  }
+
+  abstract onContentChange(
+    params: lsp.TextDocumentChangeEvent,
+    parseResults: ReturnType<AbstractLanguageServer<T>['parseDocument']>
+  ): void;
+  private handleContentChange(params: lsp.TextDocumentChangeEvent) {
+    const { document } = params;
+    const { uri } = document;
+    const { cst, errors, tokens } = this.parseDocument(document);
+    this.parseStateManager.saveParseStateForUri(uri, { cst, tokens });
+    return this.onContentChange(params, { cst, errors, tokens });
+  }
+
+  handleHover(params: lsp.TextDocumentPositionParams): lsp.Hover {
+    const { uri } = params.textDocument;
+    const document = this.documents.get(uri);
+    const content = document.getText();
+    let { cst } = this.parseStateManager.getParseStateForUri(uri);
+
+    if (!cst) {
+      const { cst: newCst } = this.parseDocument(document);
+      cst = newCst;
+      this.parseStateManager.saveParseStateForUri(uri, { cst });
+    }
+
+    const currentRuleTokens: IToken[] = [];
+    let cursorTkn: IToken;
+    let currentRule: string;
+
+    const tokenCollector = (ctx, next) => {
+      if (isCstNode(ctx.node)) {
+        return next();
+      }
+      currentRuleTokens.push(ctx.node);
+    };
+
+    const findCurrentRule = (ctx, next) => {
+      const { node, parentCtx } = ctx;
+      if (isCstNode(node)) {
+        return next();
+      }
+      // must be a token
+      if (
+        document.offsetAt(params.position) >= node.startOffset &&
+        document.offsetAt(params.position) <= node.endOffset
+      ) {
+        // found token that user's cursor is hovering over
+        cursorTkn = node;
+        currentRule = parentCtx.node.name;
+
+        traverse(parentCtx.node, tokenCollector);
+      }
+    };
+
+    traverse(cst, findCurrentRule);
+
+    // get first and last tokens' positions
+    const currentRuleRange = currentRuleTokens.reduce(
+      (memo, token) => {
+        if (token.endOffset > memo.endOffset) {
+          memo.endOffset = token.endOffset;
+        }
+        if (token.startOffset < memo.startOffset) {
+          memo.startOffset = token.startOffset;
+        }
+        return memo;
+      },
+      {
+        startOffset: content.length,
+        endOffset: 0,
+      }
+    );
+
+    if (!cursorTkn) {
+      return {
+        contents: [],
+      };
+    }
+    return {
+      contents: `\`\`\`
+${currentRule}
+\`\`\``,
+      range: {
+        start: document.positionAt(currentRuleRange.startOffset),
+        end: document.positionAt(currentRuleRange.endOffset + 1),
+      },
+    };
+  }
+
+  handleDocumentClose({ document }: lsp.TextDocumentChangeEvent) {
+    // In the future, if we want to handle things like 'GoToDefinition', we may
+    // want to keep something around here. For now, we just get rid of it.
+    this.parseStateManager.clearParseStateForUri(document.uri);
+  }
+
+  parseDocument(document: lsp.TextDocument) {
+    const content = document.getText();
+    const { cst, errors } = this.parser.parse(content);
+    const tokens = this.parser.input;
+
+    return {
+      cst,
+      tokens,
+      errors,
+    };
+  }
+
+  getLexDiagnostics(document: lsp.TextDocument, tokens: IToken[]) {
+    return tokens
+      .filter((res) => res.tokenType.tokenName === 'Unknown')
+      .map(
+        (unknownToken): lsp.Diagnostic => ({
+          severity: lsp.DiagnosticSeverity.Error,
+          message: `Unknown token`,
+          range: {
+            start: document.positionAt(unknownToken.startOffset),
+            // chevrotains' token sends our inclusive
+            end: document.positionAt(unknownToken.endOffset + 1),
+          },
+        })
+      );
+  }
+
+  getParseDiagnostics(
+    document: lsp.TextDocument,
+    errors: IRecognitionException[]
+  ) {
+    const content = document.getText();
+
+    return errors.map(
+      (error): lsp.Diagnostic => {
+        const { message, context, token } = error;
+        const { ruleStack } = context;
+        const range =
+          token.tokenType.tokenName === 'EOF'
+            ? lsp.Range.create(
+                document.positionAt(content.length),
+                document.positionAt(content.length)
+              )
+            : lsp.Range.create(
+                document.positionAt(token.startOffset),
+                document.positionAt(token.endOffset + 1)
+              );
+
+        return {
+          message,
+          source: ruleStack.length ? ruleStack.pop() : null,
+          severity: lsp.DiagnosticSeverity.Error,
+          range,
+        };
+      }
+    );
+  }
+}

--- a/packages/stardog-language-utils/src/common.ts
+++ b/packages/stardog-language-utils/src/common.ts
@@ -1,5 +1,6 @@
-export * from "./errorMessageProvider";
-export * from "./extensions";
-export * from "./language-services";
-export * from "./namespaceUtils";
-
+export * from './errorMessageProvider';
+export * from './extensions';
+export * from './language-services';
+export * from './namespaceUtils';
+export * from './parseState';
+export * from './AbstractLanguageServer';

--- a/packages/stardog-language-utils/src/index.d.ts
+++ b/packages/stardog-language-utils/src/index.d.ts
@@ -1,0 +1,2 @@
+export * from './worker';
+export * from './cli';

--- a/packages/stardog-language-utils/src/parseState.ts
+++ b/packages/stardog-language-utils/src/parseState.ts
@@ -1,0 +1,34 @@
+import { CstNode, IToken } from 'millan';
+
+export const getParseStateManager = () => {
+  const latestCstByUri: {
+    [uri: string]: CstNode;
+  } = {};
+  const latestTokensByUri: {
+    [uri: string]: IToken[];
+  } = {};
+
+  return {
+    getParseStateForUri: (uri: string): ParseState => ({
+      cst: latestCstByUri[uri],
+      tokens: latestTokensByUri[uri],
+    }),
+
+    saveParseStateForUri(uri, { cst, tokens }: ParseState) {
+      latestCstByUri[uri] = cst;
+      latestTokensByUri[uri] = tokens;
+    },
+
+    clearParseStateForUri(uri: string) {
+      latestCstByUri[uri] = undefined;
+      latestTokensByUri[uri] = undefined;
+    },
+  };
+};
+
+export interface ParseState {
+  cst: CstNode;
+  tokens?: IToken[];
+}
+
+export type ParseStateManager = ReturnType<typeof getParseStateManager>;

--- a/packages/stardog-language-utils/webpack.config.js
+++ b/packages/stardog-language-utils/webpack.config.js
@@ -1,20 +1,22 @@
 const path = require('path');
 const { isCI } = require('ci-info');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const SRC_DIR = path.join(__dirname, 'src');
+const DIST_DIR = path.join(__dirname, 'dist');
 
 const cliConfig = {
   mode: 'production',
   target: 'node',
   entry: path.join(SRC_DIR, 'cli.ts'),
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: DIST_DIR,
     filename: 'cli.js',
     library: 'stardog-language-utils',
     libraryTarget: 'umd',
     umdNamedDefine: true,
-    globalObject: 'typeof self !== \'undefined\' ? self : this', // https://github.com/webpack/webpack/issues/6525
+    globalObject: "typeof self !== 'undefined' ? self : this", // https://github.com/webpack/webpack/issues/6525
   },
   module: {
     rules: [
@@ -37,7 +39,7 @@ const cliConfig = {
           },
         ],
         exclude: [/node_modules/],
-      }
+      },
     ],
   },
   resolve: {
@@ -49,8 +51,16 @@ const cliConfig = {
       tsconfig: path.resolve(__dirname, 'tsconfig.json'),
       watch: SRC_DIR,
       // CI memory limits make building with more than one CPU for type-checking too fragile, unfortunately
-      workers: isCI ? ForkTsCheckerWebpackPlugin.ONE_CPU : ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
+      workers: isCI
+        ? ForkTsCheckerWebpackPlugin.ONE_CPU
+        : ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
     }),
+    new CopyWebpackPlugin([
+      {
+        from: `${SRC_DIR}/index.d.ts`,
+        to: path.join(DIST_DIR, 'types', 'index.d.ts'),
+      },
+    ]),
   ],
   devtool: 'source-map',
 };
@@ -60,12 +70,12 @@ const workerConfig = {
   target: 'webworker',
   entry: path.join(SRC_DIR, 'worker.ts'),
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: DIST_DIR,
     filename: 'worker.js',
     library: 'stardog-language-utils',
     libraryTarget: 'umd',
     umdNamedDefine: true,
-    globalObject: 'typeof self !== \'undefined\' ? self : this', // https://github.com/webpack/webpack/issues/6525
+    globalObject: "typeof self !== 'undefined' ? self : this", // https://github.com/webpack/webpack/issues/6525
   },
   module: {
     rules: [
@@ -88,7 +98,7 @@ const workerConfig = {
           },
         ],
         exclude: [/node_modules/],
-      }
+      },
     ],
   },
   resolve: {
@@ -100,7 +110,9 @@ const workerConfig = {
       tsconfig: path.resolve(__dirname, 'tsconfig.json'),
       watch: SRC_DIR,
       // CI memory limits make building with more than one CPU for type-checking too fragile, unfortunately
-      workers: isCI ? ForkTsCheckerWebpackPlugin.ONE_CPU : ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
+      workers: isCI
+        ? ForkTsCheckerWebpackPlugin.ONE_CPU
+        : ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
     }),
   ],
   devtool: 'source-map',
@@ -109,7 +121,7 @@ const workerConfig = {
     net: 'empty',
     fs: 'empty',
     net: 'empty',
-  }
+  },
 };
 
 module.exports = [cliConfig, workerConfig];

--- a/packages/turtle-language-server/package.json
+++ b/packages/turtle-language-server/package.json
@@ -1,8 +1,9 @@
 {
   "name": "turtle-language-server",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
+  "types": "./dist/types/TurtleLanguageServer.d.ts",
   "license": "Apache-2.0",
   "keywords": [
     "turtle",
@@ -47,7 +48,7 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "millan": "^2.0.0",
-    "stardog-language-utils": "^1.0.0",
+    "stardog-language-utils": "^1.1.1",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/turtle-language-server/src/TurtleLanguageServer.ts
+++ b/packages/turtle-language-server/src/TurtleLanguageServer.ts
@@ -1,26 +1,16 @@
 import * as lsp from 'vscode-languageserver';
-import { autoBindMethods } from 'class-autobind-decorator';
-import { errorMessageProvider } from 'stardog-language-utils';
-import { TurtleParser, isCstNode, traverse, IToken, CstNode } from 'millan';
+import {
+  AbstractLanguageServer,
+  errorMessageProvider,
+} from 'stardog-language-utils';
+import { TurtleParser } from 'millan';
 
-@autoBindMethods
-export class TurtleLanguageServer {
-  protected readonly documents = new lsp.TextDocuments();
-  private latestCst: CstNode;
-  private parser = new TurtleParser({ errorMessageProvider });
-
-  constructor(protected readonly connection: lsp.IConnection) {
-    this.documents.listen(this.connection);
-    this.documents.onDidChangeContent(this.handleContentChange);
-    this.connection.onInitialize(this.handleInitialization);
-    this.connection.onHover(this.handleHover);
+export class TurtleLanguageServer extends AbstractLanguageServer<TurtleParser> {
+  constructor(connection: lsp.IConnection) {
+    super(connection, new TurtleParser({ errorMessageProvider }));
   }
 
-  start() {
-    this.connection.listen();
-  }
-
-  handleInitialization(_params): lsp.InitializeResult {
+  onInitialization(_params: lsp.InitializeParams): lsp.InitializeResult {
     return {
       capabilities: {
         // Tell the client that the server works in NONE text document sync mode
@@ -30,133 +20,30 @@ export class TurtleLanguageServer {
     };
   }
 
-  handleContentChange(change: lsp.TextDocumentChangeEvent): void {
-    const content = change.document.getText();
-
-    const { errors: parseErrors, cst } = this.parser.parse(content);
-    this.latestCst = cst;
-    const latestTokens = this.parser.input;
+  onContentChange(
+    { document }: lsp.TextDocumentChangeEvent,
+    parseResults: ReturnType<
+      AbstractLanguageServer<TurtleParser>['parseDocument']
+    >
+  ) {
+    const { uri } = document;
+    const content = document.getText();
 
     if (!content.length) {
       this.connection.sendDiagnostics({
-        uri: change.document.uri,
+        uri,
         diagnostics: [],
       });
       return;
     }
 
-    const lexDiagnostics = latestTokens
-      .filter((res) => res.tokenType.tokenName === 'Unknown')
-      .map(
-        (unknownToken): lsp.Diagnostic => ({
-          severity: lsp.DiagnosticSeverity.Error,
-          message: `Unknown token`,
-          range: {
-            start: change.document.positionAt(unknownToken.startOffset),
-            // chevrotains' token sends our inclusive
-            end: change.document.positionAt(unknownToken.endOffset + 1),
-          },
-        })
-      );
-
-    const parseDiagnostics = parseErrors.map(
-      (error): lsp.Diagnostic => {
-        const { message, context, token } = error;
-        const { ruleStack } = context;
-        const range =
-          token.tokenType.tokenName === 'EOF'
-            ? lsp.Range.create(
-                change.document.positionAt(content.length),
-                change.document.positionAt(content.length)
-              )
-            : lsp.Range.create(
-                change.document.positionAt(token.startOffset),
-                change.document.positionAt(token.endOffset + 1)
-              );
-
-        return {
-          message,
-          source: ruleStack.length ? ruleStack.pop() : null,
-          severity: lsp.DiagnosticSeverity.Error,
-          range,
-        };
-      }
-    );
-
-    const finalDiagnostics = [...lexDiagnostics, ...parseDiagnostics];
+    const { tokens, errors } = parseResults;
+    const lexDiagnostics = this.getLexDiagnostics(document, tokens);
+    const parseDiagnostics = this.getParseDiagnostics(document, errors);
 
     return this.connection.sendDiagnostics({
-      uri: change.document.uri,
-      diagnostics: finalDiagnostics,
+      uri,
+      diagnostics: [...lexDiagnostics, ...parseDiagnostics],
     });
-  }
-
-  handleHover(params: lsp.TextDocumentPositionParams): lsp.Hover {
-    const document = this.documents.get(params.textDocument.uri);
-    const content = document.getText();
-    const cst = this.latestCst;
-
-    const currentRuleTokens: IToken[] = [];
-    let cursorTkn: IToken;
-    let currentRule: string;
-
-    const tokenCollector = (ctx, next) => {
-      if (isCstNode(ctx.node)) {
-        return next();
-      }
-      currentRuleTokens.push(ctx.node);
-    };
-
-    const findCurrentRule = (ctx, next) => {
-      const { node, parentCtx } = ctx;
-      if (isCstNode(node)) {
-        return next();
-      }
-      // must be a token
-      if (
-        document.offsetAt(params.position) >= node.startOffset &&
-        document.offsetAt(params.position) <= node.endOffset
-      ) {
-        // found token that user's cursor is hovering over
-        cursorTkn = node;
-        currentRule = parentCtx.node.name;
-
-        traverse(parentCtx.node, tokenCollector);
-      }
-    };
-
-    traverse(cst, findCurrentRule);
-
-    // get first and last tokens' positions
-    const currentRuleRange = currentRuleTokens.reduce(
-      (memo, token) => {
-        if (token.endOffset > memo.endOffset) {
-          memo.endOffset = token.endOffset;
-        }
-        if (token.startOffset < memo.startOffset) {
-          memo.startOffset = token.startOffset;
-        }
-        return memo;
-      },
-      {
-        startOffset: content.length,
-        endOffset: 0,
-      }
-    );
-
-    if (!cursorTkn) {
-      return {
-        contents: [],
-      };
-    }
-    return {
-      contents: `\`\`\`
-${currentRule}
-\`\`\``,
-      range: {
-        start: document.positionAt(currentRuleRange.startOffset),
-        end: document.positionAt(currentRuleRange.endOffset + 1),
-      },
-    };
   }
 }

--- a/packages/turtle-language-server/src/worker.ts
+++ b/packages/turtle-language-server/src/worker.ts
@@ -1,7 +1,7 @@
 import { getWorkerConnection } from 'stardog-language-utils';
-import { TurtleLanguageServer } from "./TurtleLanguageServer";
+import { TurtleLanguageServer } from './TurtleLanguageServer';
 
 const connection = getWorkerConnection();
 const server = new TurtleLanguageServer(connection);
 server.start();
-connection.onShutdown(self.close);
+connection.onExit(self.close);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,6 +1528,25 @@ byte-size@^4.0.3:
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-4.0.4.tgz#29d381709f41aae0d89c631f1c81aec88cd40b23"
   integrity sha1-KdOBcJ9BquDYnGMfHIGuyIzUCyM=
 
+cacache@^10.0.4:
+  version "10.0.4"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
+  integrity sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=
+  dependencies:
+    bluebird "^3.5.1"
+    chownr "^1.0.1"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    lru-cache "^4.1.1"
+    mississippi "^2.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^5.2.4"
+    unique-filename "^1.1.0"
+    y18n "^4.0.0"
+
 cacache@^11.0.1, cacache@^11.0.2, cacache@^11.2.0:
   version "11.3.1"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.1.tgz#d09d25f6c4aca7a6d305d141ae332613aa1d515f"
@@ -1987,6 +2006,20 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-webpack-plugin@^4.6.0:
+  version "4.6.0"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz#e7f40dd8a68477d405dd1b7a854aae324b158bae"
+  integrity sha1-5/QN2KaEd9QF3Rt6hUquMksVi64=
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    globby "^7.1.1"
+    is-glob "^4.0.0"
+    loader-utils "^1.1.0"
+    minimatch "^3.0.4"
+    p-limit "^1.0.0"
+    serialize-javascript "^1.4.0"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.1"
@@ -2800,6 +2833,15 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  integrity sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
 find-cache-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
@@ -3166,6 +3208,18 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 globby@^8.0.1:
   version "8.0.1"
@@ -4794,7 +4848,7 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=
@@ -5089,6 +5143,22 @@ minizlib@^1.1.1:
   integrity sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=
   dependencies:
     minipass "^2.2.1"
+
+mississippi@^2.0.0:
+  version "2.0.0"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
+  integrity sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^2.0.1"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -5602,7 +5672,7 @@ p-is-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
   integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
-p-limit@^1.1.0:
+p-limit@^1.0.0, p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   integrity sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=
@@ -6017,7 +6087,7 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-pump@^2.0.0:
+pump@^2.0.0, pump@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   integrity sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=
@@ -6795,6 +6865,13 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+ssri@^5.2.4:
+  version "5.3.0"
+  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
+  integrity sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=
+  dependencies:
+    safe-buffer "^5.1.1"
 
 ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,7 +1530,7 @@ byte-size@^4.0.3:
 
 cacache@^10.0.4:
   version "10.0.4"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
+  resolved "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
   integrity sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=
   dependencies:
     bluebird "^3.5.1"
@@ -2009,7 +2009,7 @@ copy-descriptor@^0.1.0:
 
 copy-webpack-plugin@^4.6.0:
   version "4.6.0"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz#e7f40dd8a68477d405dd1b7a854aae324b158bae"
+  resolved "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz#e7f40dd8a68477d405dd1b7a854aae324b158bae"
   integrity sha1-5/QN2KaEd9QF3Rt6hUquMksVi64=
   dependencies:
     cacache "^10.0.4"
@@ -2835,7 +2835,7 @@ fill-range@^4.0.0:
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
   integrity sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=
   dependencies:
     commondir "^1.0.1"
@@ -3211,7 +3211,7 @@ globby@^6.1.0:
 
 globby@^7.1.1:
   version "7.1.1"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  resolved "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
   integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
   dependencies:
     array-union "^1.0.1"
@@ -5146,7 +5146,7 @@ minizlib@^1.1.1:
 
 mississippi@^2.0.0:
   version "2.0.0"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
+  resolved "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
   integrity sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=
   dependencies:
     concat-stream "^1.5.0"
@@ -6868,7 +6868,7 @@ sshpk@^1.7.0:
 
 ssri@^5.2.4:
   version "5.3.0"
-  resolved "https://stardog.jfrog.io/stardog/api/npm/stardog-npm-virtual/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
+  resolved "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
   integrity sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=
   dependencies:
     safe-buffer "^5.1.1"


### PR DESCRIPTION
Main features:

1. Most language servers use nearly identical functionality for everything (just different parsers), so this adds an `AbstractLanguageServer` class that implements the default functionality and gets extended by language servers. (I'd normally prefer composition over inheritance, but this seemed like a case where the superclass really wasn't going to be re-used and really ought to be coupled to individual language servers.)
2. A new `ParseStateManager` is added to track latest parse state by document URI, making this state management much clearer (IMO) and making it easy to maintain parse state appropriately when switching files (closes #4).
3. Exported types (in package.json for each package) are now correct (closes #5).