### PR TITLE
prefix relationships and types when namespace update is received after those

### DIFF
--- a/packages/shacl-language-server/package.json
+++ b/packages/shacl-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shacl-language-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/ShaclLanguageServer.d.ts",

--- a/packages/shacl-language-server/package.json
+++ b/packages/shacl-language-server/package.json
@@ -53,7 +53,7 @@
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sms-language-server/package.json
+++ b/packages/sms-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sms-language-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/SmsLanguageServer.d.ts",

--- a/packages/sms-language-server/package.json
+++ b/packages/sms-language-server/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -50,7 +50,7 @@
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparql-language-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/SparqlLanguageServer.ts",

--- a/packages/sparql-language-server/src/SparqlLanguageServer.ts
+++ b/packages/sparql-language-server/src/SparqlLanguageServer.ts
@@ -96,40 +96,26 @@ export class SparqlLanguageServer extends AbstractLanguageServer<
     // indeterminate.
     if (update.namespaces) {
       this.namespaceMap = namespaceArrayToObj(update.namespaces);
-      if (!update.relationshipBindings && this.relationshipBindings) {
-        this.relationshipCompletionItems = this.buildCompletionItemsFromData(
-          this.namespaceMap,
-          this.relationshipBindings.map((binding) => ({
-            iri: binding.relationship.value,
-            count: binding.count.value,
-          }))
-        );
-      }
-      if (!update.typeBindings && this.typeBindings) {
-        this.typeCompletionItems = this.buildCompletionItemsFromData(
-          this.namespaceMap,
-          this.typeBindings.map((binding) => ({
-            iri: binding.type.value,
-            count: binding.count.value,
-          }))
-        );
-      }
     }
-    if (update.relationshipBindings) {
-      this.relationshipBindings = update.relationshipBindings;
+    if (
+      update.relationshipBindings ||
+      (update.namespaces && this.relationshipBindings)
+    ) {
+      this.relationshipBindings =
+        update.relationshipBindings || this.relationshipBindings;
       this.relationshipCompletionItems = this.buildCompletionItemsFromData(
         this.namespaceMap,
-        update.relationshipBindings.map((binding) => ({
+        this.relationshipBindings.map((binding) => ({
           iri: binding.relationship.value,
           count: binding.count.value,
         }))
       );
     }
-    if (update.typeBindings) {
-      this.typeBindings = update.typeBindings;
+    if (update.typeBindings || (update.namespaces && this.typeBindings)) {
+      this.typeBindings = update.typeBindings || this.typeBindings;
       this.typeCompletionItems = this.buildCompletionItemsFromData(
         this.namespaceMap,
-        update.typeBindings.map((binding) => ({
+        this.typeBindings.map((binding) => ({
           iri: binding.type.value,
           count: binding.count.value,
         }))

--- a/packages/sparql-language-server/src/SparqlLanguageServer.ts
+++ b/packages/sparql-language-server/src/SparqlLanguageServer.ts
@@ -94,8 +94,8 @@ export class SparqlLanguageServer extends AbstractLanguageServer<
     // Otherwise you can find yourself with 1, both or neither reflecting the
     // namespace prefixes based on the order the updates are processed, which is
     // indeterminate.
-    if (update.namespaceMap) {
-      this.namespaceMap = namespaceArrayToObj(update.namespaceMap);
+    if (update.namespaces) {
+      this.namespaceMap = namespaceArrayToObj(update.namespaces);
       if (!update.relationshipBindings && this.relationshipBindings) {
         this.relationshipCompletionItems = this.buildCompletionItemsFromData(
           this.namespaceMap,

--- a/packages/sparql-language-server/src/SparqlLanguageServer.ts
+++ b/packages/sparql-language-server/src/SparqlLanguageServer.ts
@@ -87,8 +87,13 @@ export class SparqlLanguageServer extends AbstractLanguageServer<
   }
 
   handleUpdateCompletionData(update: SparqlCompletionData) {
+    // `relationshipCompletionItems` and `typeCompletionItems` must be updated
+    // in 2 different scenarios:
     // #1 - namespaces provided after relationshipBindings or typeBindings
-    // #2 - namespacees provided before relationshipBindings or typeBindings
+    // #2 - namespaces provided before relationshipBindings or typeBindings
+    // Otherwise you can find yourself with 1, both or neither reflecting the
+    // namespace prefixes based on the order the updates are processed, which is
+    // indeterminate.
     if (update.namespaceMap) {
       this.namespaceMap = namespaceArrayToObj(update.namespaceMap);
       if (!update.relationshipBindings && this.relationshipBindings) {

--- a/packages/srs-language-server/package.json
+++ b/packages/srs-language-server/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/srs-language-server/package.json
+++ b/packages/srs-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srs-language-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/SrsLanguageServer.d.ts",

--- a/packages/stardog-graphql-language-server/package.json
+++ b/packages/stardog-graphql-language-server/package.json
@@ -50,7 +50,7 @@
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/stardog-graphql-language-server/package.json
+++ b/packages/stardog-graphql-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog-graphql-language-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/GraphqlLanguageServer.ts",

--- a/packages/stardog-language-utils/package.json
+++ b/packages/stardog-language-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog-language-utils",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types",

--- a/packages/stardog-language-utils/src/extensions.ts
+++ b/packages/stardog-language-utils/src/extensions.ts
@@ -1,30 +1,28 @@
 export enum LSPExtensionMethod {
-  DID_UPDATE_COMPLETION_DATA = "$/didUpdateCompletionData"
+  DID_UPDATE_COMPLETION_DATA = '$/didUpdateCompletionData',
 }
 
 export type SparqlCompletionData = {
-  namespaceMap?: {
-    [prefix: string]: string;
-  };
+  namespaces?: string[];
   relationshipBindings?: {
     relationship: {
-      type: "uri";
+      type: 'uri';
       value: string;
     };
     count: {
-      datatype: "http://www.w3.org/2001/XMLSchema#integer";
-      type: "literal";
+      datatype: 'http://www.w3.org/2001/XMLSchema#integer';
+      type: 'literal';
       value: string;
     };
   }[];
   typeBindings?: {
     type: {
-      type: "uri";
+      type: 'uri';
       value: string;
     };
     count: {
-      datatype: "http://www.w3.org/2001/XMLSchema#integer";
-      type: "literal";
+      datatype: 'http://www.w3.org/2001/XMLSchema#integer';
+      type: 'literal';
       value: string;
     };
   }[];

--- a/packages/turtle-language-server/package.json
+++ b/packages/turtle-language-server/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "millan": "^2.4.0",
-    "stardog-language-utils": "^1.3.1",
+    "stardog-language-utils": "^1.3.2",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/turtle-language-server/package.json
+++ b/packages/turtle-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turtle-language-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types/TurtleLanguageServer.d.ts",


### PR DESCRIPTION
@jmrog what do you think? we update these values piecemeal from Studio -- whenever any 1 of these values changes we send only that value. but the existing logic was order-dependent -- if the types or relationships are updated before the namespaces then they won't be prefixed.