### PR TITLE
Update `millan`, update GraphQL server, update SPARQL server, fix some tests

### DIFF
--- a/packages/shacl-language-server/package.json
+++ b/packages/shacl-language-server/package.json
@@ -60,8 +60,8 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sms-language-server/__tests__/integration.test.ts
+++ b/packages/sms-language-server/__tests__/integration.test.ts
@@ -64,17 +64,17 @@ describe('sms language server', () => {
 
       expect(params.diagnostics).toMatchObject([
         {
-          message: 'SqlBlock expected.',
+          message: 'Expecting token of type --> SqlBlock <-- but found --> \'select\' <--',
           source: 'SqlClause',
           severity: 1,
           range: {
             start: {
               line: 0,
-              character: 46,
+              character: 33,
             },
             end: {
               line: 0,
-              character: 47,
+              character: 39,
             },
           },
         },

--- a/packages/sms-language-server/package.json
+++ b/packages/sms-language-server/package.json
@@ -58,8 +58,8 @@
   ],
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/sparql-language-server/__tests__/integration.test.ts
+++ b/packages/sparql-language-server/__tests__/integration.test.ts
@@ -132,18 +132,18 @@ describe('sparql language server', () => {
   });
   it('handles autocompletion with longer alternatives', async (done) => {
     const docText = 'select * { ?s ?p ?o . filter(str';
-    const longAltsDoc = TextDocumentItem.create(
-      '/long-alts.rq',
+    const longAltsDoc1 = TextDocumentItem.create(
+      '/long-alts1.rq',
       'sparql',
       1,
       docText
     );
 
     await connection.sendNotification(DidOpenTextDocumentNotification.type, {
-      textDocument: longAltsDoc,
+      textDocument: longAltsDoc1,
     });
     let res = await connection.sendRequest(CompletionRequest.type, {
-      textDocument: longAltsDoc,
+      textDocument: longAltsDoc1,
       position: Position.create(0, docText.length),
     });
     expect((res as CompletionItem[]).some((item) => item.label === 'STR')).toBe(
@@ -153,12 +153,17 @@ describe('sparql language server', () => {
       (res as CompletionItem[]).some((item) => item.label === 'STRSTARTS')
     ).toBe(true);
 
-    longAltsDoc.text = `${docText}s`;
+    const longAltsDoc2 = TextDocumentItem.create(
+      '/long-alts2.rq',
+      'sparql',
+      1,
+      `${docText}s`,
+    );
     await connection.sendNotification(DidOpenTextDocumentNotification.type, {
-      textDocument: longAltsDoc,
+      textDocument: longAltsDoc2,
     });
     res = await connection.sendRequest(CompletionRequest.type, {
-      textDocument: longAltsDoc,
+      textDocument: longAltsDoc2,
       position: Position.create(0, docText.length + 1),
     });
     expect(

--- a/packages/sparql-language-server/__tests__/integration.test.ts
+++ b/packages/sparql-language-server/__tests__/integration.test.ts
@@ -130,51 +130,6 @@ describe('sparql language server', () => {
     ).toBe(true);
     done();
   });
-  it('handles autocompletion with longer alternatives', async (done) => {
-    const docText = 'select * { ?s ?p ?o . filter(str';
-    const longAltsDoc1 = TextDocumentItem.create(
-      '/long-alts1.rq',
-      'sparql',
-      1,
-      docText
-    );
-
-    await connection.sendNotification(DidOpenTextDocumentNotification.type, {
-      textDocument: longAltsDoc1,
-    });
-    let res = await connection.sendRequest(CompletionRequest.type, {
-      textDocument: longAltsDoc1,
-      position: Position.create(0, docText.length),
-    });
-    expect((res as CompletionItem[]).some((item) => item.label === 'STR')).toBe(
-      true
-    );
-    expect(
-      (res as CompletionItem[]).some((item) => item.label === 'STRSTARTS')
-    ).toBe(true);
-
-    const longAltsDoc2 = TextDocumentItem.create(
-      '/long-alts2.rq',
-      'sparql',
-      1,
-      `${docText}s`,
-    );
-    await connection.sendNotification(DidOpenTextDocumentNotification.type, {
-      textDocument: longAltsDoc2,
-    });
-    res = await connection.sendRequest(CompletionRequest.type, {
-      textDocument: longAltsDoc2,
-      position: Position.create(0, docText.length + 1),
-    });
-    expect(
-      (res as CompletionItem[]).every((item) => item.label !== 'STR')
-    ).toBe(true);
-    expect(
-      (res as CompletionItem[]).some((item) => item.label === 'STRSTARTS')
-    ).toBe(true);
-
-    done();
-  });
 });
 
 describe('w3 sparql language server', () => {

--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -58,8 +58,8 @@
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
     "memoize-one": "^5.1.1",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/srs-language-server/package.json
+++ b/packages/srs-language-server/package.json
@@ -58,8 +58,8 @@
   ],
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/stardog-graphql-language-server/package.json
+++ b/packages/stardog-graphql-language-server/package.json
@@ -57,8 +57,8 @@
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
     "lodash.uniqby": "^4.7.0",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/stardog-graphql-language-server/src/GraphQlLanguageServer.ts
+++ b/packages/stardog-graphql-language-server/src/GraphQlLanguageServer.ts
@@ -49,10 +49,7 @@ const partitionTokenTypesByLevel = (
     notTopLevel: [] as TokenType[],
   };
   stardogGraphQlTokens.filter(filter).forEach((tokenType: TokenType) => {
-    const level: keyof typeof partitioned = is(
-      tokenType,
-      stardogGraphQlTokenMap.TopLevel.name
-    )
+    const level = is(tokenType, stardogGraphQlTokenMap.TopLevel.name)
       ? 'topLevel'
       : 'notTopLevel';
     partitioned[level].push(tokenType);

--- a/packages/stardog-language-utils/package.json
+++ b/packages/stardog-language-utils/package.json
@@ -72,7 +72,7 @@
     "yargs": "^12.0.5"
   },
   "dependencies": {
-    "chevrotain": "4.4.0",
+    "chevrotain": "4.7.0",
     "escape-string-regexp": "^1.0.5",
     "lodash.uniqby": "^4.7.0",
     "millan": "^4.1.1",

--- a/packages/stardog-language-utils/package.json
+++ b/packages/stardog-language-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog-language-utils",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
   "types": "./dist/types",
@@ -75,7 +75,7 @@
     "chevrotain": "4.7.0",
     "escape-string-regexp": "^1.0.5",
     "lodash.uniqby": "^4.7.0",
-    "millan": "^4.1.1",
+    "millan": "^5.0.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/stardog-language-utils/src/AbstractLanguageServer.ts
+++ b/packages/stardog-language-utils/src/AbstractLanguageServer.ts
@@ -266,7 +266,7 @@ ${currentRule}
     this.parseStateManager.clearParseStateForUri(document.uri);
   }
 
-  parseDocument(document: TextDocument): any {
+  parseDocument(document: TextDocument) {
     const content = document.getText();
     const { cst, errors, ...otherParseData } = this.parser.parse(content);
     const tokens = this.parser.input;

--- a/packages/stardog-language-utils/src/AbstractLanguageServer.ts
+++ b/packages/stardog-language-utils/src/AbstractLanguageServer.ts
@@ -266,7 +266,7 @@ ${currentRule}
     this.parseStateManager.clearParseStateForUri(document.uri);
   }
 
-  parseDocument(document: TextDocument) {
+  parseDocument(document: TextDocument): any {
     const content = document.getText();
     const { cst, errors, ...otherParseData } = this.parser.parse(content);
     const tokens = this.parser.input;

--- a/packages/trig-language-server/package.json
+++ b/packages/trig-language-server/package.json
@@ -56,8 +56,8 @@
   ],
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/packages/turtle-language-server/package.json
+++ b/packages/turtle-language-server/package.json
@@ -56,8 +56,8 @@
   ],
   "dependencies": {
     "class-autobind-decorator": "^3.0.1",
-    "millan": "^4.0.1",
-    "stardog-language-utils": "^1.10.1",
+    "millan": "^5.0.0",
+    "stardog-language-utils": "^1.12.0",
     "vscode-languageserver": "^5.2.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,13 +1675,6 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=
 
-chevrotain@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-4.4.0.tgz#552366430143c8b28cad654f92aa83711edbd1c9"
-  integrity sha512-CS0auzIhlLxo9RCVarVZJIsKj339jJrLIdCbX3rwk/kTu7+VkYdiXiAD8aJOXJEcRc1GGcbOQ587e/85+xLxaA==
-  dependencies:
-    regexp-to-ast "0.4.0"
-
 chevrotain@4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-4.7.0.tgz#1a1acab4275cee8b1e208e6a10b1622c5b92b02e"
@@ -5081,21 +5074,12 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-millan@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/millan/-/millan-4.0.1.tgz#8168d3887b58c7a6a62649b4612ff88eea1a5518"
-  integrity sha512-ziyaJRUOjtUptycfyw+NPj5hx8UjhHa+PZOmrHBoMC3TldjTU9gUj4twoSMqa64PBxsFZN0pTaGyCbVzxhXF1A==
+millan@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/millan/-/millan-5.0.0.tgz#52be7e77f39324731a0e74406f9f64b7c531fbb2"
+  integrity sha512-H7pzUipMTbY5AFhnKrrP4Q70q2fuKvk4gKpUcusyAH8FCTwEW2UBodERJ2AdWwHnlktv98UWmW5hVbuH4cRjbA==
   dependencies:
-    chevrotain "4.4.0"
-    escape-string-regexp "^2.0.0"
-    lodash.isequal "^4.5.0"
-
-millan@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/millan/-/millan-4.1.1.tgz#dd406aefbf6d5e2938835c2a2b2e66c667dedc0e"
-  integrity sha512-IcHvCIL7BkEIG7R3OetEXaATWeN91OXsFXohYVgwp/mhBtBDH338Y9GZqnro53wafxxRuv4bVvQCYKyi8QBDAg==
-  dependencies:
-    chevrotain "4.4.0"
+    chevrotain "4.7.0"
     escape-string-regexp "^2.0.0"
     lodash.isequal "^4.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,6 +1682,13 @@ chevrotain@4.4.0:
   dependencies:
     regexp-to-ast "0.4.0"
 
+chevrotain@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-4.7.0.tgz#1a1acab4275cee8b1e208e6a10b1622c5b92b02e"
+  integrity sha512-FmXTi1hMN/6TT9NlrYP1kHHW6P7qpVzQD2vGrbsfI7wbFXXg2ANpIaN3pHPnVx/ZPHOnConE0TmyP6rguyzkZQ==
+  dependencies:
+    regexp-to-ast "0.4.0"
+
 chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -5078,6 +5085,15 @@ millan@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/millan/-/millan-4.0.1.tgz#8168d3887b58c7a6a62649b4612ff88eea1a5518"
   integrity sha512-ziyaJRUOjtUptycfyw+NPj5hx8UjhHa+PZOmrHBoMC3TldjTU9gUj4twoSMqa64PBxsFZN0pTaGyCbVzxhXF1A==
+  dependencies:
+    chevrotain "4.4.0"
+    escape-string-regexp "^2.0.0"
+    lodash.isequal "^4.5.0"
+
+millan@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/millan/-/millan-4.1.1.tgz#dd406aefbf6d5e2938835c2a2b2e66c667dedc0e"
+  integrity sha512-IcHvCIL7BkEIG7R3OetEXaATWeN91OXsFXohYVgwp/mhBtBDH338Y9GZqnro53wafxxRuv4bVvQCYKyi8QBDAg==
   dependencies:
     chevrotain "4.4.0"
     escape-string-regexp "^2.0.0"


### PR DESCRIPTION
Main changes:

1. `millan` is upgraded (incorporating a `chevrotain` update via transitive dependency).
2. The special handling for longer alternatives in the SPARQL language server is no longer necessary, given changes in `millan` for better handling of custom functions/`UNKNOWN` tokens, so it's removed.
3. The GraphQL language server needs to handle Stardog-specific directives and arguments differently, given the fix for ambiguous alternatives in `millan`. That's included.