### PR TITLE
Fix path to types of SparqlLanguageServer

### DIFF
--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
-  "types": "./dist/types/SparqlLanguageServer.d.ts",
+  "types": "./dist/lib/cli.d.ts",
   "bin": "./dist/cli.js",
   "license": "Apache-2.0",
   "keywords": [
@@ -66,9 +66,9 @@
     "clean": "rimraf ./dist",
     "lint": "node --max_old_space_size=4096 --optimize_for_size ./node_modules/.bin/tslint --project tsconfig.json",
     "pack": "node --max_old_space_size=4096 --optimize_for_size ./node_modules/.bin/webpack",
-    "build": "run-s clean lint pack types",
+    "build": "run-s clean lint pack compile",
     "dev": "webpack -w",
-    "types": "node --max_old_space_size=4096 --optimize_for_size ./node_modules/.bin/tsc --emitDeclarationOnly"
+    "compile": "node --max_old_space_size=4096 --optimize_for_size ./node_modules/.bin/tsc"
   },
   "devDependencies": {
     "ci-info": "^2.0.0",

--- a/packages/sparql-language-server/package.json
+++ b/packages/sparql-language-server/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "main": "./dist/cli.js",
   "browser": "./dist/worker.js",
-  "types": "./dist/types/SparqlLanguageServer.ts",
+  "types": "./dist/types/SparqlLanguageServer.d.ts",
   "bin": "./dist/cli.js",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/sparql-language-server/tsconfig.json
+++ b/packages/sparql-language-server/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "declarationDir": "./dist/types",
+    "outDir": "./dist/lib",
     "rootDir": "./src",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Hey there,
currently there is no way to create an instance of a SparqlLanguageServer programmatically, so I propose releasing the compiled source of it.
Also the typings were wrong for sparql-language-server.