### PR TITLE
[VET-4561] Add stardog:label completion

### DIFF
--- a/packages/stardog-language-utils/src/common-completions.ts
+++ b/packages/stardog-language-utils/src/common-completions.ts
@@ -1,6 +1,7 @@
-import { makeCompletionItemFromPrefixedNameAndNamespaceIri } from './language-services';
-import { CompletionItem } from 'vscode-languageserver';
 import memoize from 'memoize-one';
+import { CompletionItem } from 'vscode-languageserver';
+
+import { makeCompletionItemFromPrefixedNameAndNamespaceIri } from './language-services';
 
 interface CompletionDatum {
   namespaceIri: string;
@@ -192,11 +193,19 @@ const xsd: CompletionDatum = {
   properties: [],
 };
 
+const stardog: CompletionDatum = {
+  namespaceIri: 'tag:stardog:api:',
+  datatypes: [],
+  classes: [],
+  properties: ['label'],
+};
+
 const commonCompletionData = {
   owl,
   rdf,
   rdfs,
   xsd,
+  stardog,
 };
 
 export const getCommonCompletionItemsGivenNamespaces = memoize(


### PR DESCRIPTION
[VET-4561] Add stardog:label completion
I think the changes make sense, but I am having some problems testing this.  Trying to build all packages fails with an out of memory error. 
Building only the stardog-language-utils package takes about 10 min of the CPU maxed and the laptop fans spun up so it sounds like a jet. This shows some warnings, not sure if they matter.
I tried using this in Studio with a `yarn link` and also by just copying the build into node modules but I am not seeing the updated autocompletion.  I tried changing some of the existing completions and those changes also do not show up after building.  

<details>
<summary>Build warnings</summary>

```
Using 8 workers with 4096MB memory limit
Starting type checking service...
Using 8 workers with 4096MB memory limit
Warning: The 'no-boolean-literal-compare' rule requires type information.
Hash: 1fdb36a6b2ead237d52f46af6355d3f4466b6c8c
Version: webpack 4.27.1
Child
    Hash: 1fdb36a6b2ead237d52f
    Time: 40109ms
    Built at: 08/09/2024 8:47:25 AM
               Asset       Size  Chunks             Chunk Names
              cli.js    511 KiB       0  [emitted]  main
          cli.js.map   1.51 MiB       0  [emitted]  main
    types/index.d.ts  250 bytes          [emitted]
    Entrypoint main = cli.js cli.js.map
      [0] external "path" 42 bytes {0} [built]
      [3] external "fs" 42 bytes {0} [built]
      [6] external "util" 42 bytes {0} [built]
     [12] external "child_process" 42 bytes {0} [built]
     [14] /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs sync 160 bytes {0} [built]
     [15] external "net" 42 bytes {0} [built]
     [17] /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib sync 160 bytes {0} [built]
     [25] /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/lib sync 160 bytes {0} [built]
     [30] (webpack)/buildin/module.js 497 bytes {0} [built]
     [35] external "os" 42 bytes {0} [built]
     [36] external "crypto" 42 bytes {0} [built]
     [52] external "url" 42 bytes {0} [built]
     [56] /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/node_modules/yargs-parser sync 160 bytes {0} [optional] [built]
     [86] /Users/robertboskind/stardog/stardog-language-servers/node_modules/require-main-filename sync 160 bytes {0} [built]
    [124] ./src/cli.ts + 11 modules 27 KiB {0} [built]
          | ./src/cli.ts 3.05 KiB [built]
          | ./src/common.ts 308 bytes [built]
          | ./src/constants.ts 57 bytes [built]
          | ./src/language-services.ts 1.99 KiB [built]
          | ./src/common-completions.ts 5.35 KiB [built]
          | ./src/errorMessageProvider.ts 1.64 KiB [built]
          | ./src/extensions.ts 201 bytes [built]
          | ./src/namespaceUtils.ts 2.06 KiB [built]
          | ./src/parseState.ts 759 bytes [built]
          | ./src/AbstractLanguageServer.ts 10.4 KiB [built]
          | ./src/snippets.ts 174 bytes [built]
          |     + 1 hidden module
        + 110 hidden modules

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js 12:39-46
    Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js 363:33-40
    Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js 518:83-90
    Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/require-main-filename/index.js 2:25-32
    Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/files.js 84:36-54
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/main.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/files.js 319:15-28
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/main.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/lib/apply-extends.js 28:24-55
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/lib/apply-extends.js 43:82-105
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/node_modules/yargs-parser/index.js 510:21-48
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/yargs.js
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/yargs/index.js
     @ ./src/cli.ts
Child
    Hash: 46af6355d3f4466b6c8c
    Time: 42944ms
    Built at: 08/09/2024 8:47:28 AM
            Asset      Size  Chunks                    Chunk Names
        worker.js   726 KiB       0  [emitted]  [big]  main
    worker.js.map  2.16 MiB       0  [emitted]         main
    Entrypoint main [big] = worker.js worker.js.map
      [8] (webpack)/buildin/global.js 472 bytes {0} [built]
     [33] (webpack)/buildin/module.js 497 bytes {0} [built]
     [85] /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib sync 160 bytes {0} [built]
     [97] util (ignored) 15 bytes {0} [built]
     [99] util (ignored) 15 bytes {0} [built]
    [131] buffer (ignored) 15 bytes {0} [optional] [built]
    [132] crypto (ignored) 15 bytes {0} [optional] [built]
    [199] ./src/worker.ts + 11 modules 24.7 KiB {0} [built]
          | ./src/worker.ts 838 bytes [built]
          | ./src/common.ts 308 bytes [built]
          | ./src/constants.ts 57 bytes [built]
          | ./src/language-services.ts 1.99 KiB [built]
          | ./src/common-completions.ts 5.35 KiB [built]
          | ./src/errorMessageProvider.ts 1.64 KiB [built]
          | ./src/extensions.ts 201 bytes [built]
          | ./src/namespaceUtils.ts 2.06 KiB [built]
          | ./src/parseState.ts 759 bytes [built]
          | ./src/AbstractLanguageServer.ts 10.4 KiB [built]
          | ./src/snippets.ts 174 bytes [built]
          |     + 1 hidden module
        + 192 hidden modules

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/files.js 84:36-54
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/main.js
     @ ./src/worker.ts

    WARNING in /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/files.js 319:15-28
    Critical dependency: the request of a dependency is an expression
     @ /Users/robertboskind/stardog/stardog-language-servers/node_modules/vscode-languageserver/lib/main.js
     @ ./src/worker.ts

    WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
    This can impact web performance.
    Assets:
      worker.js (726 KiB)

    WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
    Entrypoints:
      main (726 KiB)
          worker.js


    WARNING in webpack performance recommendations:
    You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
    For more info visit https://webpack.js.org/guides/code-splitting/
```

</details>

[VET-4561]: https://stardog.atlassian.net/browse/VET-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ